### PR TITLE
feat(indicator): add software test coverage quality indicator

### DIFF
--- a/indicators/software_test_coverage.json
+++ b/indicators/software_test_coverage.json
@@ -1,0 +1,48 @@
+{
+  "@context": "https://w3id.org/everse/rsqi#",
+  "@id": "https://w3id.org/everse/i/indicators/software_test_coverage",
+  "@type": "SoftwareQualityIndicator",
+  "name": "Software has sufficient test coverage",
+  "abbreviation": "software_test_coverage",
+  "description": "Indicates that the test suite covers most (or ideally all) the code branches, input fields, and functionality",
+  "keywords": [
+    "test coverage",
+    "code coverage",
+    "branch coverage",
+    "coverage threshold",
+    "test completeness"
+  ],
+  "identifier": {
+    "@id": "https://w3id.org/everse/i/indicators/software_test_coverage"
+  },
+  "status": "Active",
+  "version": "0.0.1",
+  "author": {
+    "@type": "schema:Organization",
+    "name": "ELIXIR-Steers",
+    "url": "https://elixir-europe.org/about-us/how-funded/eu-projects/steers"
+  },
+  "contact": [
+    {
+      "@type": "schema:Person",
+      "name": "Daniel Garijo"
+    },
+    {
+      "@type": "schema:Person",
+      "name": "Andres Montero"
+    }
+  ],
+  "source": {
+    "url": "https://doi.org/10.5281/zenodo.17035105",
+    "name": "ELIXIR Steers D2.1 Report on best-practices and indicators available and used by selected Communities"
+  },
+  "qualityDimension": [
+    {
+      "@id": "https://w3id.org/everse/i/dimensions/reliability"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/dimensions/functional_suitability"
+    }
+  ],
+  "created": "03-12-2025"
+}


### PR DESCRIPTION
Introduces a new quality indicator describing the sufficiency of test suite coverage, including metadata, relevant quality dimensions, and references. Supports improved assessment of software reliability and functional suitability.




> [!NOTE]
>  This was not validated  through the [schema validator](https://validator.schema.org/) as requested due to producing an error : 
>
>`This @context string is unknown to the parser and we do not support remote JSON-LD context fetching. Please use a known @context value (e.g. "https://schema.org/") or define a local context`
