### PR TITLE
Add OSSR crucial indicators to community coverage table

### DIFF
--- a/website/utils/community.json
+++ b/website/utils/community.json
@@ -1,7 +1,7 @@
 {
     "codemeta_completeness": {
         "ossr": {
-            "url": "https://purl.org/escape/ossr"
+            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/"
         }
     },
     "coupling_between_objects_ok": {
@@ -27,7 +27,7 @@
             "url": "https://docs.tech.cessda.eu/software/publication.html"
         },
         "ossr": {
-            "url": "https://purl.org/escape/ossr"
+            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/onboarding/"
         }
     },
     "archived_in_software_heritage": {
@@ -41,7 +41,7 @@
             "url": "https://zenodo.org/records/17035105#ProjectDescription"
         },
         "ossr": {
-            "url": "https://purl.org/escape/ossr"
+            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/"
         }
     },
     "functional_correctness": {
@@ -66,19 +66,15 @@
             "url": "https://docs.tech.cessda.eu/software/code-archiving.html"
         },
         "ossr": {
-            "url": "https://purl.org/escape/ossr"
+            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/onboarding/"
         }
     },
     "metadata_is_up_to_date": {},
     "no_critical_vulnerability": {},
-    "no_leaked_credentials": {
-        "ossr": {
-            "url": "https://purl.org/escape/ossr"
-        }
-    },
+    "no_leaked_credentials": {},
     "persistent_and_unique_identifier": {
         "ossr": {
-            "url": "https://purl.org/escape/ossr"
+            "url": "https://escape-ossr.gitlab.io/ossr-pages/"
         }
     },
     "repository_workflows": {},
@@ -90,7 +86,7 @@
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"
         },
         "ossr": {
-            "url": "https://purl.org/escape/ossr"
+            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/onboarding/"
         }
     },
     "software_has_citation": {
@@ -117,7 +113,7 @@
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"
         },
         "ossr": {
-            "url": "https://purl.org/escape/ossr"
+            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/onboarding/"
         }
     },
     "software_has_license": {
@@ -131,7 +127,7 @@
             "url": "https://developer.skao.int/en/latest/policies/fundamental-sw-requirements.html#standards-applicable-to-derived-software"
         },
         "ossr": {
-            "url": "https://purl.org/escape/ossr"
+            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/guidelines/"
         },
         "hsf": {
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"
@@ -170,7 +166,7 @@
     "uses_tool_for_warnings_and_mistakes": {},
     "version_control_use": {
         "ossr": {
-            "url": "https://purl.org/escape/ossr"
+            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/"
         },
         "hsf": {
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"

--- a/website/utils/community.json
+++ b/website/utils/community.json
@@ -1,6 +1,8 @@
 {
     "codemeta_completeness": {
-        
+        "ossr": {
+            "url": "https://purl.org/escape/ossr"
+        }
     },
     "coupling_between_objects_ok": {
         "envri": {
@@ -23,6 +25,9 @@
         },
         "cessda": {
             "url": "https://docs.tech.cessda.eu/software/publication.html"
+        },
+        "ossr": {
+            "url": "https://purl.org/escape/ossr"
         }
     },
     "archived_in_software_heritage": {
@@ -30,15 +35,13 @@
             "url": "https://docs.tech.cessda.eu/software/code-archiving.html"
         }
     },
-    "dependency_management": {
-        
-    },
+    "dependency_management": {},
     "descriptive_metadata": {
         "elixir": {
             "url": "https://zenodo.org/records/17035105#ProjectDescription"
         },
         "ossr": {
-            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/"
+            "url": "https://purl.org/escape/ossr"
         }
     },
     "functional_correctness": {
@@ -46,58 +49,48 @@
             "url": "https://zenodo.org/records/17035105#FunctionalCorrectness"
         }
     },
-    "has_ci-tests": {
-        
-    },
-    "has_no_linting_issues": {
-        
-    },
-    "has_published_package": {
-        "ossr": {
-            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/"
-        }
-    },
+    "has_ci-tests": {},
+    "has_no_linting_issues": {},
+    "has_published_package": {},
     "has_releases": {
         "cessda": {
             "url": "https://docs.tech.cessda.eu/software/releases.html"
-        },
-        "ossr": {
-            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/"
         }
     },
-    "human_code_review_requirement": {
-        
-    },
+    "human_code_review_requirement": {},
     "listed_in_registry": {
-        
         "elixir": {
             "url": "https://zenodo.org/records/17035105#ListedInRegistries"
         },
         "cessda": {
             "url": "https://docs.tech.cessda.eu/software/code-archiving.html"
+        },
+        "ossr": {
+            "url": "https://purl.org/escape/ossr"
         }
     },
-    "metadata_is_up_to_date": {
-        
-    },
-    "no_critical_vulnerability": {
-        
-    },
+    "metadata_is_up_to_date": {},
+    "no_critical_vulnerability": {},
     "no_leaked_credentials": {
-        
+        "ossr": {
+            "url": "https://purl.org/escape/ossr"
+        }
     },
     "persistent_and_unique_identifier": {
-        
+        "ossr": {
+            "url": "https://purl.org/escape/ossr"
+        }
     },
-    "repository_workflows": {
-        
-    },
+    "repository_workflows": {},
     "requirements_specified": {
         "skao": {
             "url": "https://developer.skao.int/en/latest/policies/fundamental-sw-requirements.html#standards-applicable-to-derived-software"
         },
         "hsf": {
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"
+        },
+        "ossr": {
+            "url": "https://purl.org/escape/ossr"
         }
     },
     "software_has_citation": {
@@ -122,6 +115,9 @@
         },
         "hsf": {
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"
+        },
+        "ossr": {
+            "url": "https://purl.org/escape/ossr"
         }
     },
     "software_has_license": {
@@ -135,7 +131,7 @@
             "url": "https://developer.skao.int/en/latest/policies/fundamental-sw-requirements.html#standards-applicable-to-derived-software"
         },
         "ossr": {
-            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/"
+            "url": "https://purl.org/escape/ossr"
         },
         "hsf": {
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"
@@ -170,15 +166,11 @@
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"
         }
     },
-    "uses_fuzzing": {
-        
-    },
-    "uses_tool_for_warnings_and_mistakes": {
-        
-    },
+    "uses_fuzzing": {},
+    "uses_tool_for_warnings_and_mistakes": {},
     "version_control_use": {
         "ossr": {
-            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/"
+            "url": "https://purl.org/escape/ossr"
         },
         "hsf": {
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"
@@ -229,11 +221,7 @@
             "url": "https://ieeexplore.ieee.org/document/11216562"
         }
     },
-    "software_is_containerized": {
-        "ossr": {
-            "url": "https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/"
-        }
-    },
+    "software_is_containerized": {},
     "has_active_communication_channels": {
         "hsf": {
             "url": "https://hepsoftwarefoundation.org/projects/guidelines.html"


### PR DESCRIPTION
## Summary

Updates `website/utils/community.json` so the OSSR column of the community coverage table (`website/community.html`) shows exactly the indicators OSSR requires as crucial, each linking to the OSSR requirements PURL: https://purl.org/escape/ossr

## Indicators and rationale

| Indicator | Explanation |
| --- | --- |
| `software_has_license` | In the OSSR requirements |
| `persistent_and_unique_identifier` | Required to be in Zenodo/OSSR |
| `listed_in_registry` | OSSR definition |
| `descriptive_metadata` | OSSR requirement |
| `version_control_use` | Must have to make a release on Zenodo |
| `software_has_documentation` | Minimal documentation falls under the set of development practices ([OSSR checklist](https://escape-ossr.gitlab.io/ossr-pages/contribute/checklist/)) |
| `requirements_specified` | Falls under the set of good development practices |
| `no_leaked_credentials` | Following EVERSE recommendation |
| `archived_in_scholarly_repository` | OSSR definition |
| `codemeta_completeness` | Minimal completeness required |

These ones were removed:
- `has_published_package` - from the definition of this indicator, a package is something such as a pypi or npm package, not a requirement for the OSSR
- `has_releases` - from the definition _ the project's source repository MUST include interim versions for review between releases; it MUST NOT include only final releases_ - not an OSSR requirement
- `software_is_containerized` - it is recommended but not required, so it really depends how one reads the community table. It's also tier-dependent.
